### PR TITLE
Rels optimisation

### DIFF
--- a/src/main/java/org/humancellatlas/ingest/analysis/Analysis.java
+++ b/src/main/java/org/humancellatlas/ingest/analysis/Analysis.java
@@ -10,6 +10,7 @@ import org.humancellatlas.ingest.core.MetadataDocument;
 import org.humancellatlas.ingest.core.SubmissionDate;
 import org.humancellatlas.ingest.core.UpdateDate;
 import org.humancellatlas.ingest.core.Uuid;
+import org.humancellatlas.ingest.envelope.SubmissionEnvelope;
 import org.humancellatlas.ingest.file.File;
 import org.humancellatlas.ingest.project.Project;
 import org.springframework.data.mongodb.core.mapping.DBRef;
@@ -31,12 +32,15 @@ public class Analysis extends MetadataDocument {
     private final @DBRef List<File> files;
     private final @DBRef List<BundleManifest> inputBundleManifests;
 
+    private @DBRef SubmissionEnvelope submissionEnvelope;
+
     protected Analysis() {
         super(EntityType.ANALYSIS, null, new SubmissionDate(new Date()), new UpdateDate(new Date()), null, null);
         this.projects = new ArrayList<>();
         this.assays = new ArrayList<>();
         this.files = new ArrayList<>();
         this.inputBundleManifests = new ArrayList<>();
+        this.submissionEnvelope = null;
     }
 
     public Analysis(EntityType type,
@@ -48,12 +52,14 @@ public class Analysis extends MetadataDocument {
                     List<Assay> assays,
                     List<File> files,
                     List<BundleManifest> inputBundleManifests,
+                    SubmissionEnvelope submissionEnvelope,
                     Object content) {
         super(type, uuid, submissionDate, updateDate, accession, content);
         this.projects = projects;
         this.assays = assays;
         this.files = files;
         this.inputBundleManifests = inputBundleManifests;
+        this.submissionEnvelope = submissionEnvelope;
     }
 
     @JsonCreator
@@ -67,7 +73,14 @@ public class Analysis extends MetadataDocument {
              new ArrayList<>(),
              new ArrayList<>(),
              new ArrayList<>(),
+             null,
              content);
+    }
+
+    public Analysis addToEnvelope(SubmissionEnvelope submissionEnvelope) {
+        this.submissionEnvelope = submissionEnvelope;
+
+        return this;
     }
 
     public Analysis addFile(File file) {

--- a/src/main/java/org/humancellatlas/ingest/analysis/AnalysisRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/analysis/AnalysisRepository.java
@@ -1,6 +1,9 @@
 package org.humancellatlas.ingest.analysis;
 
 import org.humancellatlas.ingest.core.Uuid;
+import org.humancellatlas.ingest.envelope.SubmissionEnvelope;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 /**
@@ -11,4 +14,6 @@ import org.springframework.data.mongodb.repository.MongoRepository;
  */
 public interface AnalysisRepository extends MongoRepository<Analysis, String> {
     public Analysis findByUuid(Uuid uuid);
+
+    public Page<Analysis> findBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope, Pageable pageable);
 }

--- a/src/main/java/org/humancellatlas/ingest/analysis/AnalysisService.java
+++ b/src/main/java/org/humancellatlas/ingest/analysis/AnalysisService.java
@@ -33,9 +33,8 @@ public class AnalysisService {
     }
 
     public Analysis addAnalysisToSubmissionEnvelope(SubmissionEnvelope submissionEnvelope, Analysis analysis) {
-        Analysis result = getAnalysisRepository().save(analysis);
-        getSubmissionEnvelopeRepository().save(submissionEnvelope.addAnalysis(result));
-        return result;
+        analysis.addToEnvelope(submissionEnvelope);
+        return getAnalysisRepository().save(analysis);
     }
 
     public Analysis resolveBundleReferencesForAnalysis(Analysis analysis, BundleReference bundleReference) {

--- a/src/main/java/org/humancellatlas/ingest/assay/Assay.java
+++ b/src/main/java/org/humancellatlas/ingest/assay/Assay.java
@@ -8,6 +8,7 @@ import org.humancellatlas.ingest.core.MetadataDocument;
 import org.humancellatlas.ingest.core.SubmissionDate;
 import org.humancellatlas.ingest.core.UpdateDate;
 import org.humancellatlas.ingest.core.Uuid;
+import org.humancellatlas.ingest.envelope.SubmissionEnvelope;
 import org.humancellatlas.ingest.file.File;
 import org.humancellatlas.ingest.project.Project;
 import org.humancellatlas.ingest.protocol.Protocol;
@@ -31,12 +32,15 @@ public class Assay extends MetadataDocument {
     private final @DBRef List<Protocol> protocols;
     private final @DBRef List<File> files;
 
+    private SubmissionEnvelope submissionEnvelope;
+
     protected Assay() {
         super(EntityType.ASSAY, null, new SubmissionDate(new Date()), new UpdateDate(new Date()), null, null);
         this.samples = new ArrayList<>();
         this.projects = new ArrayList<>();
         this.protocols = new ArrayList<>();
         this.files = new ArrayList<>();
+        this.submissionEnvelope = null;
     }
 
     public Assay(EntityType type,
@@ -48,12 +52,14 @@ public class Assay extends MetadataDocument {
                  List<Project> projects,
                  List<Protocol> protocols,
                  List<File> files,
+                 SubmissionEnvelope submissionEnvelope,
                  Object content) {
         super(type, uuid, submissionDate, updateDate, accession, content);
         this.samples = samples;
         this.projects = projects;
         this.protocols = protocols;
         this.files = files;
+        this.submissionEnvelope = submissionEnvelope;
     }
 
     @JsonCreator
@@ -67,7 +73,14 @@ public class Assay extends MetadataDocument {
              new ArrayList<>(),
              new ArrayList<>(),
              new ArrayList<>(),
+             null,
              content);
+    }
+
+    public Assay addToSubmissionEnvelope(SubmissionEnvelope submissionEnvelope) {
+        this.submissionEnvelope = submissionEnvelope;
+
+        return this;
     }
 
     public Assay addFile(File file) {

--- a/src/main/java/org/humancellatlas/ingest/assay/Assay.java
+++ b/src/main/java/org/humancellatlas/ingest/assay/Assay.java
@@ -32,7 +32,7 @@ public class Assay extends MetadataDocument {
     private final @DBRef List<Protocol> protocols;
     private final @DBRef List<File> files;
 
-    private SubmissionEnvelope submissionEnvelope;
+    private @DBRef SubmissionEnvelope submissionEnvelope;
 
     protected Assay() {
         super(EntityType.ASSAY, null, new SubmissionDate(new Date()), new UpdateDate(new Date()), null, null);

--- a/src/main/java/org/humancellatlas/ingest/assay/AssayRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/assay/AssayRepository.java
@@ -1,6 +1,9 @@
 package org.humancellatlas.ingest.assay;
 
 import org.humancellatlas.ingest.core.Uuid;
+import org.humancellatlas.ingest.envelope.SubmissionEnvelope;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 /**
@@ -11,4 +14,6 @@ import org.springframework.data.mongodb.repository.MongoRepository;
  */
 public interface AssayRepository extends MongoRepository<Assay, String> {
     public Assay findByUuid(Uuid uuid);
+
+    public Page<Assay> findBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope, Pageable pageable);
 }

--- a/src/main/java/org/humancellatlas/ingest/assay/AssayService.java
+++ b/src/main/java/org/humancellatlas/ingest/assay/AssayService.java
@@ -21,8 +21,7 @@ public class AssayService {
     private final @NonNull AssayRepository assayRepository;
 
     public Assay addAssayToSubmissionEnvelope(SubmissionEnvelope submissionEnvelope, Assay assay) {
-        Assay result = getAssayRepository().save(assay);
-        getSubmissionEnvelopeRepository().save(submissionEnvelope.addAssay(result));
-        return result;
+        assay.addToSubmissionEnvelope(submissionEnvelope);
+        return getAssayRepository().save(assay);
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/core/web/Links.java
+++ b/src/main/java/org/humancellatlas/ingest/core/web/Links.java
@@ -13,6 +13,19 @@ public class Links {
     public static final String SUBMIT_URL = "/confirmation";
     public static final String SUBMIT_REL = "submit";
 
+    public static final String ANALYSES_URL = "/analyses";
+    public static final String ANALYSES_REL = "analyses";
+    public static final String ASSAYS_URL = "/assays";
+    public static final String ASSAYS_REL = "assays";
+    public static final String FILES_URL = "/files";
+    public static final String FILES_REL = "files";
+    public static final String PROJECTS_URL = "/projects";
+    public static final String PROJECTS_REL = "projects";
+    public static final String PROTOCOLS_URL = "/protocols";
+    public static final String PROTOCOLS_REL = "protocols";
+    public static final String SAMPLES_URL = "/samples";
+    public static final String SAMPLES_REL = "samples";
+
     // Links for analyses
     public static final String BUNDLE_REF_URL = "/bundleReferences";
     public static final String BUNDLE_REF_REL = "add-input-bundles";

--- a/src/main/java/org/humancellatlas/ingest/envelope/SubmissionEnvelope.java
+++ b/src/main/java/org/humancellatlas/ingest/envelope/SubmissionEnvelope.java
@@ -24,82 +24,20 @@ import java.util.List;
  */
 @Getter
 public class SubmissionEnvelope extends AbstractEntity {
-    private final @DBRef List<Project> projects;
-    private final @DBRef List<Sample> samples;
-    private final @DBRef List<Assay> assays;
-    private final @DBRef List<Analysis> analyses;
-    private final @DBRef List<Protocol> protocols;
-    private final @DBRef List<File> files;
-
     private @Setter SubmissionStatus submissionStatus;
-
 
     public SubmissionEnvelope(Uuid uuid,
                               SubmissionDate submissionDate,
                               UpdateDate updateDate,
-                              SubmissionStatus submissionStatus,
-                              List<Project> projects,
-                              List<Sample> samples,
-                              List<Assay> assays,
-                              List<Analysis> analyses,
-                              List<Protocol> protocols,
-                              List<File> files) {
+                              SubmissionStatus submissionStatus) {
         super(EntityType.SUBMISSION, uuid, submissionDate, updateDate);
         this.submissionStatus = submissionStatus;
-        this.projects = projects;
-        this.samples = samples;
-        this.assays = assays;
-        this.analyses = analyses;
-        this.protocols = protocols;
-        this.files = files;
     }
 
     public SubmissionEnvelope() {
         this(null,
              new SubmissionDate(new Date()),
              new UpdateDate(new Date()),
-             SubmissionStatus.DRAFT,
-             new ArrayList<>(),
-             new ArrayList<>(),
-             new ArrayList<>(),
-             new ArrayList<>(),
-             new ArrayList<>(),
-             new ArrayList<>());
-    }
-
-    public SubmissionEnvelope addAnalysis(Analysis analysis) {
-        this.analyses.add(analysis);
-
-        return this;
-    }
-
-    public SubmissionEnvelope addAssay(Assay assay) {
-        this.assays.add(assay);
-
-        return this;
-    }
-
-    public SubmissionEnvelope addProject(Project project) {
-        this.projects.add(project);
-
-        return this;
-    }
-
-    public SubmissionEnvelope addProtocol(Protocol protocol) {
-        this.protocols.add(protocol);
-
-        return this;
-    }
-
-    public SubmissionEnvelope addSample(Sample sample) {
-        this.samples.add(sample);
-
-        return this;
-    }
-
-    public SubmissionEnvelope addFile(File file) {
-        this.files.add(file);
-
-        return this;
+             SubmissionStatus.DRAFT);
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/envelope/SubmissionEnvelopeRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/envelope/SubmissionEnvelopeRepository.java
@@ -1,9 +1,7 @@
 package org.humancellatlas.ingest.envelope;
 
-import org.humancellatlas.ingest.envelope.SubmissionEnvelope;
+import org.humancellatlas.ingest.core.Uuid;
 import org.springframework.data.mongodb.repository.MongoRepository;
-
-import java.util.UUID;
 
 /**
  * Javadocs go here!
@@ -12,5 +10,5 @@ import java.util.UUID;
  * @date 31/08/17
  */
 public interface SubmissionEnvelopeRepository extends MongoRepository<SubmissionEnvelope, String> {
-    public SubmissionEnvelope findByUuid(UUID uuid);
+    public SubmissionEnvelope findByUuid(Uuid uuid);
 }

--- a/src/main/java/org/humancellatlas/ingest/file/File.java
+++ b/src/main/java/org/humancellatlas/ingest/file/File.java
@@ -11,18 +11,22 @@ import org.humancellatlas.ingest.core.MetadataDocument;
 import org.humancellatlas.ingest.core.SubmissionDate;
 import org.humancellatlas.ingest.core.UpdateDate;
 import org.humancellatlas.ingest.core.Uuid;
+import org.humancellatlas.ingest.envelope.SubmissionEnvelope;
 
 import java.util.Date;
 
 @Getter
 @Setter
 public class File extends MetadataDocument {
+    private SubmissionEnvelope submissionEnvelope;
+
     private String fileName;
     private String cloudUrl;
     private Checksums checksums;
 
     protected File() {
         super(EntityType.FILE, null, new SubmissionDate(new Date()), new UpdateDate(new Date()), null, null);
+        this.submissionEnvelope = null;
         this.cloudUrl = "";
         this.fileName = "";
         this.checksums = null;
@@ -33,11 +37,13 @@ public class File extends MetadataDocument {
                    SubmissionDate submissionDate,
                    UpdateDate updateDate,
                    Accession accession,
+                   SubmissionEnvelope submissionEnvelope,
                    String fileName,
                    String cloudUrl,
                    Checksums checksums,
                    Object content) {
         super(type, uuid, submissionDate, updateDate, accession, content);
+        this.submissionEnvelope = submissionEnvelope;
         this.fileName = fileName;
         this.cloudUrl = cloudUrl;
         this.checksums = checksums;
@@ -51,9 +57,24 @@ public class File extends MetadataDocument {
              new SubmissionDate(new Date()),
              new UpdateDate(new Date()),
              null,
+             null,
              fileName,
              null,
              null,
              content);
+    }
+
+    public File addToSubmissionEnvelope(SubmissionEnvelope submissionEnvelope) {
+        this.submissionEnvelope = submissionEnvelope;
+
+        return this;
+    }
+
+    public boolean isInEnvelope(SubmissionEnvelope submissionEnvelope) {
+        return this.submissionEnvelope.equals(submissionEnvelope);
+    }
+
+    public boolean isInEnvelopeWithUuid(Uuid uuid) {
+        return this.submissionEnvelope.getUuid().equals(uuid);
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/file/FileRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/file/FileRepository.java
@@ -1,7 +1,9 @@
 package org.humancellatlas.ingest.file;
 
 import org.humancellatlas.ingest.core.Uuid;
+import org.humancellatlas.ingest.envelope.SubmissionEnvelope;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 import java.util.List;
@@ -11,6 +13,8 @@ import java.util.List;
  */
 public interface FileRepository extends MongoRepository<File, String> {
     public File findByUuid(Uuid uuid);
+
+    public Page<File> findBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope, Pageable pageable);
 
     public List<File> findBySubmissionEnvelopeUuid(Uuid uuid);
 }

--- a/src/main/java/org/humancellatlas/ingest/file/FileRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/file/FileRepository.java
@@ -1,11 +1,16 @@
 package org.humancellatlas.ingest.file;
 
 import org.humancellatlas.ingest.core.Uuid;
+import org.springframework.data.domain.Page;
 import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
 
 /**
  * Created by rolando on 06/09/2017.
  */
 public interface FileRepository extends MongoRepository<File, String> {
     public File findByUuid(Uuid uuid);
+
+    public List<File> findBySubmissionEnvelopeUuid(Uuid uuid);
 }

--- a/src/main/java/org/humancellatlas/ingest/file/FileService.java
+++ b/src/main/java/org/humancellatlas/ingest/file/FileService.java
@@ -3,6 +3,7 @@ package org.humancellatlas.ingest.file;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.humancellatlas.ingest.core.Uuid;
 import org.humancellatlas.ingest.core.exception.CoreEntityNotFoundException;
 import org.humancellatlas.ingest.envelope.SubmissionEnvelope;
 import org.humancellatlas.ingest.envelope.SubmissionEnvelopeRepository;
@@ -27,16 +28,15 @@ public class FileService {
     private final @NonNull FileRepository fileRepository;
 
     public File addFileToSubmissionEnvelope(SubmissionEnvelope submissionEnvelope, File file) {
-        File result = getFileRepository().save(file);
-        getSubmissionEnvelopeRepository().save(submissionEnvelope.addFile(result));
-        return result;
+        file.addToSubmissionEnvelope(submissionEnvelope);
+        return getFileRepository().save(file);
     }
 
-    public File updateStagedFileUrl(UUID envelopeUuid, String fileName, String newFileUrl) throws CoreEntityNotFoundException {
+    public File updateStagedFileUrl(Uuid envelopeUuid, String fileName, String newFileUrl) throws CoreEntityNotFoundException {
         Optional<SubmissionEnvelope> envelope = Optional.ofNullable(submissionEnvelopeRepository.findByUuid(envelopeUuid));
 
         if(envelope.isPresent()) {
-            List<File> filesInEnvelope = submissionEnvelopeRepository.findByUuid(envelopeUuid).getFiles();
+            List<File> filesInEnvelope = fileRepository.findBySubmissionEnvelopeUuid(envelopeUuid);
 
             Optional<File> fileToUpdate = filesInEnvelope.stream()
                     .filter(file -> file.getFileName().equals(fileName))

--- a/src/main/java/org/humancellatlas/ingest/file/web/FileMessage.java
+++ b/src/main/java/org/humancellatlas/ingest/file/web/FileMessage.java
@@ -2,6 +2,7 @@ package org.humancellatlas.ingest.file.web;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.humancellatlas.ingest.core.Uuid;
 
 import java.util.UUID;
 
@@ -13,5 +14,5 @@ import java.util.UUID;
 public class FileMessage {
     private final String cloudUrl;
     private final String fileName;
-    private final UUID envelopeUuid;
+    private final Uuid envelopeUuid;
 }

--- a/src/main/java/org/humancellatlas/ingest/project/Project.java
+++ b/src/main/java/org/humancellatlas/ingest/project/Project.java
@@ -8,6 +8,8 @@ import org.humancellatlas.ingest.core.MetadataDocument;
 import org.humancellatlas.ingest.core.SubmissionDate;
 import org.humancellatlas.ingest.core.UpdateDate;
 import org.humancellatlas.ingest.core.Uuid;
+import org.humancellatlas.ingest.envelope.SubmissionEnvelope;
+import org.springframework.data.mongodb.core.mapping.DBRef;
 
 import java.util.Date;
 
@@ -19,12 +21,32 @@ import java.util.Date;
  */
 @Getter
 public class Project extends MetadataDocument {
+    private @DBRef SubmissionEnvelope submissionEnvelope;
+
     protected Project() {
         super(EntityType.PROJECT, null, new SubmissionDate(new Date()), new UpdateDate(new Date()), null, null);
+        this.submissionEnvelope = null;
+    }
+
+    public Project(EntityType type,
+                   Uuid uuid,
+                   SubmissionDate submissionDate,
+                   UpdateDate updateDate,
+                   Accession accession,
+                   SubmissionEnvelope submissionEnvelope,
+                   Object content) {
+        super(type, uuid, submissionDate, updateDate, accession, content);
+        this.submissionEnvelope = submissionEnvelope;
     }
 
     @JsonCreator
     public Project(Object content) {
-        super(EntityType.PROJECT, null, new SubmissionDate(new Date()), new UpdateDate(new Date()), null, content);
+        this(EntityType.PROJECT, null, new SubmissionDate(new Date()), new UpdateDate(new Date()), null, null, content);
+    }
+
+    public Project addToSubmissionEnvelope(SubmissionEnvelope submissionEnvelope) {
+        this.submissionEnvelope = submissionEnvelope;
+
+        return this;
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/project/ProjectRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/project/ProjectRepository.java
@@ -1,6 +1,9 @@
 package org.humancellatlas.ingest.project;
 
 import org.humancellatlas.ingest.core.Uuid;
+import org.humancellatlas.ingest.envelope.SubmissionEnvelope;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 /**
@@ -11,4 +14,6 @@ import org.springframework.data.mongodb.repository.MongoRepository;
  */
 public interface ProjectRepository extends MongoRepository<Project, String> {
     public Project findByUuid(Uuid uuid);
+
+    public Page<Project> findBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope, Pageable pageable);
 }

--- a/src/main/java/org/humancellatlas/ingest/project/ProjectService.java
+++ b/src/main/java/org/humancellatlas/ingest/project/ProjectService.java
@@ -21,8 +21,7 @@ public class ProjectService {
     private final @NonNull ProjectRepository projectRepository;
 
     public Project addProjectToSubmissionEnvelope(SubmissionEnvelope submissionEnvelope, Project project) {
-        Project result = getProjectRepository().save(project);
-        getSubmissionEnvelopeRepository().save(submissionEnvelope.addProject(result));
-        return result;
+        project.addToSubmissionEnvelope(submissionEnvelope);
+        return getProjectRepository().save(project);
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/protocol/Protocol.java
+++ b/src/main/java/org/humancellatlas/ingest/protocol/Protocol.java
@@ -2,12 +2,14 @@ package org.humancellatlas.ingest.protocol;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
-import org.humancellatlas.ingest.core.MetadataDocument;
 import org.humancellatlas.ingest.core.Accession;
 import org.humancellatlas.ingest.core.EntityType;
+import org.humancellatlas.ingest.core.MetadataDocument;
 import org.humancellatlas.ingest.core.SubmissionDate;
 import org.humancellatlas.ingest.core.UpdateDate;
 import org.humancellatlas.ingest.core.Uuid;
+import org.humancellatlas.ingest.envelope.SubmissionEnvelope;
+import org.springframework.data.mongodb.core.mapping.DBRef;
 
 import java.util.Date;
 
@@ -19,12 +21,38 @@ import java.util.Date;
  */
 @Getter
 public class Protocol extends MetadataDocument {
+    private @DBRef SubmissionEnvelope submissionEnvelope;
+
     protected Protocol() {
         super(EntityType.PROTOCOL, null, new SubmissionDate(new Date()), new UpdateDate(new Date()), null, null);
+        this.submissionEnvelope = null;
+    }
+
+    public Protocol(EntityType type,
+                    Uuid uuid,
+                    SubmissionDate submissionDate,
+                    UpdateDate updateDate,
+                    Accession accession,
+                    SubmissionEnvelope submissionEnvelope,
+                    Object content) {
+        super(type, uuid, submissionDate, updateDate, accession, content);
+        this.submissionEnvelope = submissionEnvelope;
     }
 
     @JsonCreator
     public Protocol(Object content) {
-        super(EntityType.PROTOCOL, null, new SubmissionDate(new Date()), new UpdateDate(new Date()), null, content);
+        this(EntityType.PROTOCOL,
+             null,
+             new SubmissionDate(new Date()),
+             new UpdateDate(new Date()),
+             null,
+             null,
+             content);
+    }
+
+    public Protocol addToSubmissionEnvelope(SubmissionEnvelope submissionEnvelope) {
+        this.submissionEnvelope = submissionEnvelope;
+
+        return this;
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/protocol/ProtocolRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/protocol/ProtocolRepository.java
@@ -1,6 +1,9 @@
 package org.humancellatlas.ingest.protocol;
 
 import org.humancellatlas.ingest.core.Uuid;
+import org.humancellatlas.ingest.envelope.SubmissionEnvelope;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 /**
@@ -11,4 +14,6 @@ import org.springframework.data.mongodb.repository.MongoRepository;
  */
 public interface ProtocolRepository extends MongoRepository<Protocol, String> {
     public Protocol findByUuid(Uuid uuid);
+
+    public Page<Protocol> findBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope, Pageable pageable);
 }

--- a/src/main/java/org/humancellatlas/ingest/protocol/ProtocolService.java
+++ b/src/main/java/org/humancellatlas/ingest/protocol/ProtocolService.java
@@ -21,8 +21,7 @@ public class ProtocolService {
     private final @NonNull ProtocolRepository protocolRepository;
 
     public Protocol addProtocolToSubmissionEnvelope(SubmissionEnvelope submissionEnvelope, Protocol protocol) {
-        Protocol result = getProtocolRepository().save(protocol);
-        getSubmissionEnvelopeRepository().save(submissionEnvelope.addProtocol(protocol));
-        return result;
+        protocol.addToSubmissionEnvelope(submissionEnvelope);
+        return getProtocolRepository().save(protocol);
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/sample/Sample.java
+++ b/src/main/java/org/humancellatlas/ingest/sample/Sample.java
@@ -8,6 +8,7 @@ import org.humancellatlas.ingest.core.MetadataDocument;
 import org.humancellatlas.ingest.core.SubmissionDate;
 import org.humancellatlas.ingest.core.UpdateDate;
 import org.humancellatlas.ingest.core.Uuid;
+import org.humancellatlas.ingest.envelope.SubmissionEnvelope;
 import org.humancellatlas.ingest.project.Project;
 import org.humancellatlas.ingest.protocol.Protocol;
 import org.springframework.data.mongodb.core.mapping.DBRef;
@@ -28,11 +29,14 @@ public class Sample extends MetadataDocument {
     private final @DBRef List<Project> projects;
     private final @DBRef List<Protocol> protocols;
 
+    private @DBRef SubmissionEnvelope submissionEnvelope;
+
     protected Sample() {
         super(EntityType.SAMPLE, null, new SubmissionDate(new Date()), new UpdateDate(new Date()), null, null);
         this.derivedFromSamples = new ArrayList<>();
         this.projects = new ArrayList<>();
         this.protocols = new ArrayList<>();
+        this.submissionEnvelope = null;
     }
 
     public Sample(EntityType type,
@@ -43,6 +47,7 @@ public class Sample extends MetadataDocument {
                   List<Sample> derivedFromSamples,
                   List<Project> projects,
                   List<Protocol> protocols,
+                  SubmissionEnvelope submissionEnvelope,
                   Object content) {
         super(type, uuid, submissionDate, updateDate, accession, content);
         this.derivedFromSamples = derivedFromSamples;
@@ -60,6 +65,13 @@ public class Sample extends MetadataDocument {
              new ArrayList<>(),
              new ArrayList<>(),
              new ArrayList<>(),
+             null,
              content);
+    }
+
+    public Sample addToSubmissionEnvelope(SubmissionEnvelope submissionEnvelope) {
+        this.submissionEnvelope = submissionEnvelope;
+
+        return this;
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/sample/SampleRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/sample/SampleRepository.java
@@ -1,6 +1,9 @@
 package org.humancellatlas.ingest.sample;
 
 import org.humancellatlas.ingest.core.Uuid;
+import org.humancellatlas.ingest.envelope.SubmissionEnvelope;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 /**
@@ -11,4 +14,6 @@ import org.springframework.data.mongodb.repository.MongoRepository;
  */
 public interface SampleRepository extends MongoRepository<Sample, String> {
     public Sample findByUuid(Uuid uuid);
+
+    public Page<Sample> findBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope, Pageable pageable);
 }

--- a/src/main/java/org/humancellatlas/ingest/sample/SampleService.java
+++ b/src/main/java/org/humancellatlas/ingest/sample/SampleService.java
@@ -21,8 +21,7 @@ public class SampleService {
     private final @NonNull SampleRepository sampleRepository;
 
     public Sample addSampleToSubmissionEnvelope(SubmissionEnvelope submissionEnvelope, Sample sample) {
-        Sample result = getSampleRepository().save(sample);
-        getSubmissionEnvelopeRepository().save(submissionEnvelope.addSample(result));
-        return result;
+        sample.addToSubmissionEnvelope(submissionEnvelope);
+        return getSampleRepository().save(sample);
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/submission/web/SubmissionController.java
+++ b/src/main/java/org/humancellatlas/ingest/submission/web/SubmissionController.java
@@ -61,7 +61,7 @@ public class SubmissionController {
         return ResponseEntity.ok(getPagedResourcesAssembler().toResource(analyses, resourceAssembler));
     }
 
-    @RequestMapping(path = "/submissionEnvelopes/{sub_id}/assay", method = RequestMethod.GET)
+    @RequestMapping(path = "/submissionEnvelopes/{sub_id}/assays", method = RequestMethod.GET)
     ResponseEntity<?> getAssays(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
                                 Pageable pageable,
                                 final PersistentEntityResourceAssembler resourceAssembler) {

--- a/src/main/java/org/humancellatlas/ingest/submission/web/SubmissionController.java
+++ b/src/main/java/org/humancellatlas/ingest/submission/web/SubmissionController.java
@@ -1,18 +1,32 @@
 package org.humancellatlas.ingest.submission.web;
 
+import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.humancellatlas.ingest.analysis.Analysis;
+import org.humancellatlas.ingest.analysis.AnalysisRepository;
+import org.humancellatlas.ingest.assay.Assay;
+import org.humancellatlas.ingest.assay.AssayRepository;
 import org.humancellatlas.ingest.core.web.Links;
 import org.humancellatlas.ingest.envelope.SubmissionEnvelope;
-import org.humancellatlas.ingest.messaging.Constants;
+import org.humancellatlas.ingest.file.File;
+import org.humancellatlas.ingest.file.FileRepository;
+import org.humancellatlas.ingest.project.Project;
+import org.humancellatlas.ingest.project.ProjectRepository;
+import org.humancellatlas.ingest.protocol.Protocol;
+import org.humancellatlas.ingest.protocol.ProtocolRepository;
+import org.humancellatlas.ingest.sample.Sample;
+import org.humancellatlas.ingest.sample.SampleRepository;
 import org.humancellatlas.ingest.submission.SubmissionReceipt;
 import org.humancellatlas.ingest.submission.SubmissionService;
-import org.springframework.amqp.core.AmqpTemplate;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.rest.webmvc.PersistentEntityResourceAssembler;
+import org.springframework.data.rest.webmvc.RepositoryRestController;
+import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.ExposesResourceFor;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -23,14 +37,71 @@ import org.springframework.web.bind.annotation.RequestMethod;
  * @author Tony Burdett
  * @date 31/08/17
  */
-@Controller
+@RepositoryRestController
 @ExposesResourceFor(SubmissionEnvelope.class)
-@RequestMapping("/submissionEnvelopes/{id}")
 @RequiredArgsConstructor
+@Getter
 public class SubmissionController {
     private final @NonNull SubmissionService submissionService;
 
-    @RequestMapping(path = Links.SUBMIT_URL, method = RequestMethod.PUT)
+    private final @NonNull AnalysisRepository analysisRepository;
+    private final @NonNull AssayRepository assayRepository;
+    private final @NonNull FileRepository fileRepository;
+    private final @NonNull ProjectRepository projectRepository;
+    private final @NonNull ProtocolRepository protocolRepository;
+    private final @NonNull SampleRepository sampleRepository;
+
+    private final @NonNull PagedResourcesAssembler pagedResourcesAssembler;
+
+    @RequestMapping(path = "/submissionEnvelopes/{sub_id}/analyses", method = RequestMethod.GET)
+    ResponseEntity<?> getAnalyses(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
+                                             Pageable pageable,
+                                             final PersistentEntityResourceAssembler resourceAssembler) {
+        Page<Analysis> analyses = getAnalysisRepository().findBySubmissionEnvelope(submissionEnvelope, pageable);
+        return ResponseEntity.ok(getPagedResourcesAssembler().toResource(analyses, resourceAssembler));
+    }
+
+    @RequestMapping(path = "/submissionEnvelopes/{sub_id}/assay", method = RequestMethod.GET)
+    ResponseEntity<?> getAssays(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
+                                Pageable pageable,
+                                final PersistentEntityResourceAssembler resourceAssembler) {
+        Page<Assay> assays = getAssayRepository().findBySubmissionEnvelope(submissionEnvelope, pageable);
+        return ResponseEntity.ok(getPagedResourcesAssembler().toResource(assays, resourceAssembler));
+    }
+
+    @RequestMapping(path = "/submissionEnvelopes/{sub_id}/files", method = RequestMethod.GET)
+    ResponseEntity<?> getFiles(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
+                               Pageable pageable,
+                               final PersistentEntityResourceAssembler resourceAssembler) {
+        Page<File> files = getFileRepository().findBySubmissionEnvelope(submissionEnvelope, pageable);
+        return ResponseEntity.ok(getPagedResourcesAssembler().toResource(files, resourceAssembler));
+    }
+
+    @RequestMapping(path = "/submissionEnvelopes/{sub_id}/projects", method = RequestMethod.GET)
+    ResponseEntity<?> getProjects(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
+                                  Pageable pageable,
+                                  final PersistentEntityResourceAssembler resourceAssembler) {
+        Page<Project> projects = getProjectRepository().findBySubmissionEnvelope(submissionEnvelope, pageable);
+        return ResponseEntity.ok(getPagedResourcesAssembler().toResource(projects, resourceAssembler));
+    }
+
+    @RequestMapping(path = "/submissionEnvelopes/{sub_id}/protocols", method = RequestMethod.GET)
+    ResponseEntity<?> getProtocols(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
+                                   Pageable pageable,
+                                   final PersistentEntityResourceAssembler resourceAssembler) {
+        Page<Protocol> protocols = getProtocolRepository().findBySubmissionEnvelope(submissionEnvelope, pageable);
+        return ResponseEntity.ok(getPagedResourcesAssembler().toResource(protocols, resourceAssembler));
+    }
+
+    @RequestMapping(path = "/submissionEnvelopes/{sub_id}/samples", method = RequestMethod.GET)
+    ResponseEntity<?> getSamples(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
+                                 Pageable pageable,
+                                 final PersistentEntityResourceAssembler resourceAssembler) {
+        Page<Sample> samples = getSampleRepository().findBySubmissionEnvelope(submissionEnvelope, pageable);
+        return ResponseEntity.ok(getPagedResourcesAssembler().toResource(samples, resourceAssembler));
+    }
+
+    @RequestMapping(path = "/submissionEnvelopes/{id}" + Links.SUBMIT_URL, method = RequestMethod.PUT)
     HttpEntity<?> submitEnvelope(@PathVariable("id") SubmissionEnvelope submissionEnvelope) {
         SubmissionReceipt receipt = submissionService.submitEnvelope(submissionEnvelope);
         return ResponseEntity.accepted().body(receipt);

--- a/src/main/java/org/humancellatlas/ingest/submission/web/SubmissionEnvelopeResourceProcessor.java
+++ b/src/main/java/org/humancellatlas/ingest/submission/web/SubmissionEnvelopeResourceProcessor.java
@@ -25,8 +25,55 @@ public class SubmissionEnvelopeResourceProcessor implements ResourceProcessor<Re
         return entityLinks.linkForSingleResource(submissionEnvelope).slash(Links.SUBMIT_URL).withRel(Links.SUBMIT_REL);
     }
 
+    private Link getAnalysesLink(SubmissionEnvelope submissionEnvelope) {
+        return entityLinks.linkForSingleResource(submissionEnvelope)
+                .slash(Links.ANALYSES_URL)
+                .withRel(Links.ANALYSES_REL);
+    }
+
+    private Link getAssaysLink(SubmissionEnvelope submissionEnvelope) {
+        return entityLinks.linkForSingleResource(submissionEnvelope)
+                .slash(Links.ASSAYS_URL)
+                .withRel(Links.ASSAYS_REL);
+    }
+
+    private Link getFilesLink(SubmissionEnvelope submissionEnvelope) {
+        return entityLinks.linkForSingleResource(submissionEnvelope)
+                .slash(Links.FILES_URL)
+                .withRel(Links.FILES_REL);
+    }
+
+    private Link getProjectsLink(SubmissionEnvelope submissionEnvelope) {
+        return entityLinks.linkForSingleResource(submissionEnvelope)
+                .slash(Links.PROJECTS_URL)
+                .withRel(Links.PROJECTS_REL);
+    }
+
+    private Link getProtocolsLink(SubmissionEnvelope submissionEnvelope) {
+        return entityLinks.linkForSingleResource(submissionEnvelope)
+                .slash(Links.PROTOCOLS_URL)
+                .withRel(Links.PROTOCOLS_REL);
+    }
+
+    private Link getSamplesLink(SubmissionEnvelope submissionEnvelope) {
+        return entityLinks.linkForSingleResource(submissionEnvelope)
+                .slash(Links.SAMPLES_URL)
+                .withRel(Links.SAMPLES_REL);
+    }
+
     public Resource<SubmissionEnvelope> process(Resource<SubmissionEnvelope> resource) {
-        resource.add(getSubmitLink(resource.getContent()));
+        SubmissionEnvelope submissionEnvelope = resource.getContent();
+
+        resource.add(getAnalysesLink(submissionEnvelope));
+        resource.add(getAssaysLink(submissionEnvelope));
+        resource.add(getFilesLink(submissionEnvelope));
+        resource.add(getProjectsLink(submissionEnvelope));
+        resource.add(getProtocolsLink(submissionEnvelope));
+        resource.add(getSamplesLink(submissionEnvelope));
+
+        // should be dependent on validation state
+        resource.add(getSubmitLink(submissionEnvelope));
+
         return resource;
     }
 }


### PR DESCRIPTION
All the submission envelope relationships have been reversed so are now owned by the metadata documents.  Controllers support adding the inverse links back to the submission envelope.  This should massively minimise the amount of data that needs to be retrieved when fetching any objects (previously, submission envelope would be dynamically retrieving all encapsulated objects)

@simonjupp Can you test this for performance against your loader script?  If you're happy we can merge.