### PR TITLE
Jittered backoff

### DIFF
--- a/src/main/java/org/humancellatlas/ingest/messaging/MessageSender.java
+++ b/src/main/java/org/humancellatlas/ingest/messaging/MessageSender.java
@@ -25,9 +25,9 @@ public class MessageSender {
     private final @NonNull Queue<QueuedMessage> accessionMessageBatch = new PriorityQueue<>(Comparator.comparing(QueuedMessage::getQueuedDate));
     private final @NonNull Queue<QueuedMessage> exportMessageBatch = new PriorityQueue<>(Comparator.comparing(QueuedMessage::getQueuedDate));
 
-    private final @NonNull int DELAY_TIME_VALIDATION_MESSAGES = 0;
-    private final @NonNull int DELAY_TIME_EXPORTER_MESSAGES = 0;
-    private final @NonNull int DELAY_TIME_ACCESSIONER_MESSAGES = 0;
+    private final int DELAY_TIME_VALIDATION_MESSAGES = 0;
+    private final int DELAY_TIME_EXPORTER_MESSAGES = 0;
+    private final int DELAY_TIME_ACCESSIONER_MESSAGES = 0;
 
 
     public void queueValidationMessage(String exchange, String routingKey, MetadataDocumentMessage payload){

--- a/src/main/java/org/humancellatlas/ingest/messaging/MessageSender.java
+++ b/src/main/java/org/humancellatlas/ingest/messaging/MessageSender.java
@@ -25,9 +25,9 @@ public class MessageSender {
     private final @NonNull Queue<QueuedMessage> accessionMessageBatch = new PriorityQueue<>(Comparator.comparing(QueuedMessage::getQueuedDate));
     private final @NonNull Queue<QueuedMessage> exportMessageBatch = new PriorityQueue<>(Comparator.comparing(QueuedMessage::getQueuedDate));
 
-    private final int DELAY_TIME_VALIDATION_MESSAGES = 0;
-    private final int DELAY_TIME_EXPORTER_MESSAGES = 0;
-    private final int DELAY_TIME_ACCESSIONER_MESSAGES = 0;
+    private final int DELAY_TIME_VALIDATION_MESSAGES = 10;
+    private final int DELAY_TIME_EXPORTER_MESSAGES = 5;
+    private final int DELAY_TIME_ACCESSIONER_MESSAGES = 2;
 
 
     public void queueValidationMessage(String exchange, String routingKey, MetadataDocumentMessage payload){

--- a/src/main/java/org/humancellatlas/ingest/messaging/MessageSender.java
+++ b/src/main/java/org/humancellatlas/ingest/messaging/MessageSender.java
@@ -25,6 +25,11 @@ public class MessageSender {
     private final @NonNull Queue<QueuedMessage> accessionMessageBatch = new PriorityQueue<>(Comparator.comparing(QueuedMessage::getQueuedDate));
     private final @NonNull Queue<QueuedMessage> exportMessageBatch = new PriorityQueue<>(Comparator.comparing(QueuedMessage::getQueuedDate));
 
+    private final @NonNull int DELAY_TIME_VALIDATION_MESSAGES = 0;
+    private final @NonNull int DELAY_TIME_EXPORTER_MESSAGES = 0;
+    private final @NonNull int DELAY_TIME_ACCESSIONER_MESSAGES = 0;
+
+
     public void queueValidationMessage(String exchange, String routingKey, MetadataDocumentMessage payload){
         QueuedMessage message = new QueuedMessage(new Date(), exchange, routingKey, payload);
         this.validationMessageBatch.add(message);
@@ -42,17 +47,17 @@ public class MessageSender {
 
     @Scheduled(fixedDelay = 1000)
     private void sendValidationMessages(){
-        sendFromQueue(this.validationMessageBatch, 40);
+        sendFromQueue(this.validationMessageBatch, this.DELAY_TIME_VALIDATION_MESSAGES);
     }
 
     @Scheduled(fixedDelay = 1000)
     private void sendAccessionMessages(){
-        sendFromQueue(this.accessionMessageBatch, 20);
+        sendFromQueue(this.accessionMessageBatch, this.DELAY_TIME_ACCESSIONER_MESSAGES);
     }
 
     @Scheduled(fixedDelay = 1000)
     private void sendExportMessages(){
-        sendFromQueue(this.exportMessageBatch, 10);
+        sendFromQueue(this.exportMessageBatch, this.DELAY_TIME_EXPORTER_MESSAGES);
     }
 
     private void sendFromQueue(Queue<QueuedMessage> messageQueue, int delayTimeSeconds){

--- a/src/main/java/org/humancellatlas/ingest/state/MetadataStateChangeListener.java
+++ b/src/main/java/org/humancellatlas/ingest/state/MetadataStateChangeListener.java
@@ -33,14 +33,18 @@ public class MetadataStateChangeListener extends AbstractMongoEventListener<Meta
         SubmissionEnvelope latestEnvelope = null;
         MetadataDocument metadataDocument = event.getSource();
         SubmissionEnvelope envelope = metadataDocument.getOpenSubmissionEnvelope();
-        try {
-            latestEnvelope = this.getStateEngine().notifySubmissionEnvelopeOfMetadataDocumentChange(envelope, metadataDocument);
-        } catch (Exception e) {
-            getLog().error("Save propagation error", e);
-            latestEnvelope = envelope;
-        } finally {
-            this.getStateEngine().analyseStateOfEnvelope(latestEnvelope)
-                .ifPresent(event1 -> getLog().debug("Event triggered on submission envelope", event1));
+        if(envelope != null) {
+            try {
+                latestEnvelope = this.getStateEngine()
+                    .notifySubmissionEnvelopeOfMetadataDocumentChange(envelope, metadataDocument);
+            } catch (Exception e) {
+                getLog().error("Save propagation error", e);
+                latestEnvelope = envelope;
+            } finally {
+                this.getStateEngine().analyseStateOfEnvelope(latestEnvelope)
+                    .ifPresent(
+                        event1 -> getLog().debug("Event triggered on submission envelope", event1));
+            }
         }
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/state/MetadataStateChangeListener.java
+++ b/src/main/java/org/humancellatlas/ingest/state/MetadataStateChangeListener.java
@@ -35,8 +35,7 @@ public class MetadataStateChangeListener extends AbstractMongoEventListener<Meta
         SubmissionEnvelope envelope = metadataDocument.getOpenSubmissionEnvelope();
         try {
             latestEnvelope = this.getStateEngine().notifySubmissionEnvelopeOfMetadataDocumentChange(envelope, metadataDocument);
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             getLog().error("Save propagation error", e);
             latestEnvelope = envelope;
         } finally {

--- a/src/main/java/org/humancellatlas/ingest/state/StateEngine.java
+++ b/src/main/java/org/humancellatlas/ingest/state/StateEngine.java
@@ -224,13 +224,13 @@ public class StateEngine {
             }
             catch (Exception e) {
                 lastException = e;
+                int backoff = new Random().nextInt(Math.min(cap * 1000, ((int) Math.pow(base * 2, tries)) * 1000));
                 getLog().trace("Exception on metadata operation", e);
                 getLog().debug(String.format(
                         "Encountered exception whilst updating submission envelope of metadata change... " +
-                                "will reattempt (tries now = %s)",
-                        tries));
+                                "will reattempt (tries now = %s) after sleeping for backoff of %s milliseconds",
+                        tries, backoff));
                 try {
-                    int backoff = new Random().nextInt(Math.min(cap * 1000, ((int) Math.pow(base * 2, tries)) * 1000));
                     TimeUnit.MILLISECONDS.sleep(backoff);
                 }
                 catch (InterruptedException e1) {

--- a/src/main/java/org/humancellatlas/ingest/state/StateEngine.java
+++ b/src/main/java/org/humancellatlas/ingest/state/StateEngine.java
@@ -1,5 +1,6 @@
 package org.humancellatlas.ingest.state;
 
+import java.util.Random;
 import lombok.Getter;
 import lombok.NonNull;
 import org.humancellatlas.ingest.core.Event;
@@ -95,7 +96,10 @@ public class StateEngine {
         final Event event = new SubmissionEvent(submissionEnvelope.getSubmissionState(), targetState);
         executorService.submit(() -> {
             // we'll retry events here if they fail
+            // see https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
             int tries = 0;
+            int cap = 20; // max of 20 seconds of backoff
+            int base = 1; // initially 1 second of backoff
             Exception lastException = null;
             SubmissionEnvelope envelope = submissionEnvelope;
             while (tries < MAX_RETRIES) {
@@ -117,7 +121,8 @@ public class StateEngine {
                                     "will reattempt (tries now = %s)",
                             tries));
                     try {
-                        TimeUnit.SECONDS.sleep(1);
+                        int backoff = new Random().nextInt(Math.min(cap * 1000, ((int) Math.pow(base * 2, tries)) * 1000));
+                        TimeUnit.MILLISECONDS.sleep(backoff);
                     }
                     catch (InterruptedException e1) {
                         // just continue
@@ -157,6 +162,8 @@ public class StateEngine {
     public Optional<Event> analyseStateOfEnvelope(SubmissionEnvelope submissionEnvelope) {
         // we'll retry events here if they fail
         int tries = 0;
+        int cap = 20; // max of 20 seconds of backoff
+        int base = 1; // initially 1 second of backoff
         Exception lastException = null;
         SubmissionEnvelope envelope = submissionEnvelope;
         while (tries < MAX_RETRIES) {
@@ -181,7 +188,8 @@ public class StateEngine {
                                 "will reattempt (tries now = %s)",
                         tries));
                 try {
-                    TimeUnit.SECONDS.sleep(1);
+                    int backoff = new Random().nextInt(Math.min(cap * 1000, ((int) Math.pow(base * 2, tries)) * 1000));
+                    TimeUnit.MILLISECONDS.sleep(backoff);
                 }
                 catch (InterruptedException e1) {
                     // just continue
@@ -199,6 +207,8 @@ public class StateEngine {
                                                                  MetadataDocument metadataDocument) {
         // we'll retry events here if they fail
         int tries = 0;
+        int cap = 20; // max of 20 seconds of backoff
+        int base = 1; // initially 1 second of backoff
         Exception lastException = null;
         SubmissionEnvelope envelope = submissionEnvelope;
         while (tries < MAX_RETRIES) {
@@ -220,7 +230,8 @@ public class StateEngine {
                                 "will reattempt (tries now = %s)",
                         tries));
                 try {
-                    TimeUnit.SECONDS.sleep(1);
+                    int backoff = new Random().nextInt(Math.min(cap * 1000, ((int) Math.pow(base * 2, tries)) * 1000));
+                    TimeUnit.MILLISECONDS.sleep(backoff);
                 }
                 catch (InterruptedException e1) {
                     // just continue

--- a/src/main/java/org/humancellatlas/ingest/state/StateEngine.java
+++ b/src/main/java/org/humancellatlas/ingest/state/StateEngine.java
@@ -112,8 +112,9 @@ public class StateEngine {
                     // is this an event that needs to be posted to a queue?
                     postMessageIfRequired(envelope, targetState);
                     return;
-                }
-                catch (Exception e) {
+                } catch (InvalidSubmissionStateException e) {
+                    throw e;
+                } catch (Exception e) {
                     lastException = e;
                     getLog().trace("Exception on envelope operation", e);
                     getLog().debug(String.format(
@@ -221,8 +222,7 @@ public class StateEngine {
                 else {
                     return envelope;
                 }
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 lastException = e;
                 int backoff = new Random().nextInt(Math.min(cap * 1000, ((int) Math.pow(base * 2, tries)) * 1000));
                 getLog().trace("Exception on metadata operation", e);

--- a/src/main/java/org/humancellatlas/ingest/submission/SubmissionEnvelope.java
+++ b/src/main/java/org/humancellatlas/ingest/submission/SubmissionEnvelope.java
@@ -10,7 +10,6 @@ import org.humancellatlas.ingest.core.Event;
 import org.humancellatlas.ingest.core.MetadataDocument;
 import org.humancellatlas.ingest.core.Uuid;
 import org.humancellatlas.ingest.state.InvalidSubmissionStateException;
-import org.humancellatlas.ingest.state.MetadataDocumentStateException;
 import org.humancellatlas.ingest.state.SubmissionState;
 import org.humancellatlas.ingest.state.ValidationState;
 import org.slf4j.Logger;
@@ -120,12 +119,7 @@ public class SubmissionEnvelope extends AbstractEntity {
             // if this doc is in draft, it's either a new document or has new content, so it's ok to add to state tracker
             // but if not, we need to throw an exception here
             if (!metadataDocument.getValidationState().equals(ValidationState.DRAFT)) {
-                throw new MetadataDocumentStateException(String.format(
-                        "Metadata document '%s: %s', in state '%s', was not being tracked by containing envelope %s",
-                        metadataDocument.getClass().getSimpleName(),
-                        metadataDocument.getId(),
-                        metadataDocument.getValidationState(),
-                        this.getId(), metadataDocument.getOpenSubmissionEnvelope().getId()));
+               getLog().debug(String.format("Attempted to track a document(type: %s, id: %s) for an envelope(id: %s) that was not in DRAFT state", metadataDocument.getType(), metadataDocument.getId(), this.getId()));
             }
             else {
                 doValidationStateUpdate(metadataDocument);


### PR DESCRIPTION
Decreasing contention on submissionEnvelopes by using randomized backoffs. Seems to work a lot better now. Documents don't appear to be getting stuck in the wrong state anymore.

Also turned off the validation message buffer's delay, still works well.