### PR TITLE
memory-optimized findAssays() for core stability

### DIFF
--- a/src/main/java/org/humancellatlas/ingest/process/ProcessRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/process/ProcessRepository.java
@@ -11,8 +11,10 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RestResource;
 import org.springframework.web.bind.annotation.CrossOrigin;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 @CrossOrigin
 public interface ProcessRepository extends MongoRepository<Process, String> {
@@ -36,5 +38,8 @@ public interface ProcessRepository extends MongoRepository<Process, String> {
     public Page<Process> findBySubmissionEnvelopesContainingAndValidationState(@Param
             ("envelopeUri") SubmissionEnvelope submissionEnvelope, @Param("state")
             ValidationState state, Pageable pageable);
+
+    @RestResource(exported = false)
+    public Stream<Process> findAllByIdIn(Collection<String> ids);
 
 }

--- a/src/main/java/org/humancellatlas/ingest/process/ProcessService.java
+++ b/src/main/java/org/humancellatlas/ingest/process/ProcessService.java
@@ -136,8 +136,15 @@ public class ProcessService {
 
     }
 
-    public Collection<Process> findAssays(SubmissionEnvelope submissionEnvelope) {
-        Set<Process> results = new LinkedHashSet<>();
+    /**
+     *
+     * Find all assay process IDs in a submission
+     *
+     * @param submissionEnvelope
+     * @return A collection of IDs of every assay process in a submission
+     */
+    public Set<String> findAssays(SubmissionEnvelope submissionEnvelope) {
+        Set<String> results = new LinkedHashSet<>();
         long fileStartTime = System.currentTimeMillis();
 
         long fileEndTime = System.currentTimeMillis();
@@ -150,7 +157,7 @@ public class ProcessService {
                       .forEach(derivedFile -> {
                           for (Process derivedByProcess : derivedFile.getDerivedByProcesses()) {
                               if (!biomaterialRepository.findByInputToProcessesContains(derivedByProcess).isEmpty()) {
-                                  results.add(derivedByProcess);
+                                  results.add(derivedByProcess.getId());
                               }
                           }
                       });
@@ -162,13 +169,20 @@ public class ProcessService {
         return results;
     }
 
-    public Collection<Process> findAnalyses(SubmissionEnvelope submissionEnvelope) {
-        Set<Process> results = new LinkedHashSet<>();
+    /**
+     *
+     * Find all analysis process IDs in a submission
+     *
+     * @param submissionEnvelope
+     * @return A collection of IDs of every analysis process in a submission
+     */
+    public Set<String> findAnalyses(SubmissionEnvelope submissionEnvelope) {
+        Set<String> results = new LinkedHashSet<>();
         fileRepository.findBySubmissionEnvelopesContains(submissionEnvelope)
                       .forEach(derivedFile -> {
                           for (Process derivedByProcess : derivedFile.getDerivedByProcesses()) {
                               if (!fileRepository.findByInputToProcessesContains(derivedByProcess).isEmpty()) {
-                                  results.add(derivedByProcess);
+                                  results.add(derivedByProcess.getId());
                               }
                           }
                       });


### PR DESCRIPTION
Rather than enumerating simultaneously all of a submission's assay/analysis Processes in memory, enumerates just the IDs of the assay/analysis Processes and handles them in batches. The trade-off here is an increase in time to do findAssays()/findAnalyses() in exchange for more stable memory usage and so better reliability