### PR TITLE
Migration Support & Feature Compatibility 3.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 	implementation 'com.auth0:jwks-rsa:0.8.3'
 	implementation 'org.jolokia:jolokia-core'
 	implementation 'org.zalando:problem:0.23.0'
+	implementation 'com.github.mongobee:mongobee:0.13'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/org/humancellatlas/ingest/config/MigrationConfiguration.java
+++ b/src/main/java/org/humancellatlas/ingest/config/MigrationConfiguration.java
@@ -1,0 +1,19 @@
+package org.humancellatlas.ingest.config;
+
+import com.github.mongobee.Mongobee;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MigrationConfiguration {
+    @Value("${spring.data.mongodb.uri}")
+    private String mongoURI;
+
+    @Bean
+    public Mongobee Configure() {
+        Mongobee runner = new Mongobee(mongoURI);
+        runner.setChangeLogsScanPackage("org.humancellatlas.ingest.migrations");
+        return runner;
+    }
+}

--- a/src/main/java/org/humancellatlas/ingest/migrations/MongoChangeLog.java
+++ b/src/main/java/org/humancellatlas/ingest/migrations/MongoChangeLog.java
@@ -1,0 +1,14 @@
+package org.humancellatlas.ingest.migrations;
+
+import com.github.mongobee.changeset.ChangeLog;
+import com.github.mongobee.changeset.ChangeSet;
+import com.mongodb.client.MongoDatabase;
+import org.bson.Document;
+
+@ChangeLog
+public class MongoChangeLog {
+    @ChangeSet(order = "2019-10-30", id="featureCompatibilityVersion 3.4", author = "alexie.staffer@ebi.ac.uk")
+    public void featureCompatibilityThreeFour(MongoDatabase db) {
+        db.runCommand( new Document("setFeatureCompatibilityVersion", "3.4"));
+    }
+}

--- a/src/test/java/org/humancellatlas/ingest/IngestCoreApplicationTests.java
+++ b/src/test/java/org/humancellatlas/ingest/IngestCoreApplicationTests.java
@@ -1,13 +1,17 @@
 package org.humancellatlas.ingest;
 
+import org.humancellatlas.ingest.config.MigrationConfiguration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class IngestCoreApplicationTests {
+	@MockBean
+	MigrationConfiguration migrationConfiguration;
 
 	@Test
 	public void contextLoads() {

--- a/src/test/java/org/humancellatlas/ingest/schemas/SchemaScraperTest.java
+++ b/src/test/java/org/humancellatlas/ingest/schemas/SchemaScraperTest.java
@@ -1,6 +1,7 @@
 package org.humancellatlas.ingest.schemas;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import org.humancellatlas.ingest.config.MigrationConfiguration;
 import org.humancellatlas.ingest.schemas.schemascraper.SchemaScraper;
 import org.humancellatlas.ingest.schemas.schemascraper.impl.S3BucketSchemaScraper;
 
@@ -34,6 +35,8 @@ public class SchemaScraperTest {
     @Autowired SchemaService schemaService;
 
     @MockBean SchemaRepository schemaRepository;
+
+    @MockBean MigrationConfiguration migrationConfiguration;
 
     WireMockServer wireMockServer;
 

--- a/src/test/java/org/humancellatlas/ingest/stagingjob/StagingJobRepositoryTest.java
+++ b/src/test/java/org/humancellatlas/ingest/stagingjob/StagingJobRepositoryTest.java
@@ -1,9 +1,11 @@
 package org.humancellatlas.ingest.stagingjob;
 
+import org.humancellatlas.ingest.config.MigrationConfiguration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -15,6 +17,8 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class StagingJobRepositoryTest {
+    @MockBean
+    MigrationConfiguration migrationConfiguration;
 
     @Autowired
     StagingJobRepository stagingJobRepository;


### PR DESCRIPTION
Add Migration support to ingest-core, to allow us to write migrations to existing data to support new code.
The first migration is to update the Mongo Feature Compatibility Version to 3.4, to match the current Mongo Server Version.

# Rollout plan
1. Migrate to feature compatibility **3.4** (This PR)
2. Update [Docker configuration](https://github.com/HumanCellAtlas/ingest-core/blob/master/docker-compose.yml#L17) to **3.6**
3. Migrate to feature compatibility **3.6**
4. Update [Docker configuration](https://github.com/HumanCellAtlas/ingest-core/blob/master/docker-compose.yml#L17) to **4.0**
5. Migrate to feature compatibility **4.0**
6. Update [Docker configuration](https://github.com/HumanCellAtlas/ingest-core/blob/master/docker-compose.yml#L17) to **4.2**
7. Migrate to feature compatibility **4.2**
