### PR TITLE
Revert to using list for documents to update

### DIFF
--- a/src/main/java/org/humancellatlas/ingest/biomaterial/BiomaterialRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/biomaterial/BiomaterialRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RestResource;
 import org.springframework.web.bind.annotation.CrossOrigin;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -31,6 +32,9 @@ public interface BiomaterialRepository extends MongoRepository<Biomaterial, Stri
 
     @RestResource(exported = false)
     Stream<Biomaterial> findBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope);
+
+    @RestResource(exported = false)
+    Collection<Biomaterial> findAllBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope);
 
     @RestResource(rel = "findBySubmissionAndValidationState")
     public Page<Biomaterial> findBySubmissionEnvelopeAndValidationState(@Param

--- a/src/main/java/org/humancellatlas/ingest/bundle/BundleManifestService.java
+++ b/src/main/java/org/humancellatlas/ingest/bundle/BundleManifestService.java
@@ -14,8 +14,6 @@ import org.springframework.stereotype.Service;
 
 import java.text.DecimalFormat;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -24,18 +22,16 @@ public class BundleManifestService {
     BundleManifestRepository bundleManifestRepository;
     private final Logger log = LoggerFactory.getLogger(getClass());
 
-    public Map<String, Set<MetadataDocument>> bundleManifestsForDocuments(Stream<MetadataDocument> documents) {
+    public Map<String, Set<MetadataDocument>> bundleManifestsForDocuments(Collection<MetadataDocument> documents) {
 
         Map<String, Set<MetadataDocument>> hits = new HashMap<>();
 
         long fileStartTime = System.currentTimeMillis();
         Iterator<BundleManifest> iterator = allManifestsIterator();
-        final AtomicInteger count = new AtomicInteger();
 
         while(iterator.hasNext()) {
             BundleManifest bundleManifest = iterator.next();
             documents.forEach(document -> {
-            	count.incrementAndGet();
                 String documentUuid = document.getUuid().getUuid().toString();
                 String bundleUuid = bundleManifest.getBundleUuid();
                 EntityType documentType = document.getType();
@@ -55,7 +51,7 @@ public class BundleManifestService {
         float fileQueryTime = ((float)(fileEndTime - fileStartTime)) / 1000;
         String fileQt = new DecimalFormat("#,###.##").format(fileQueryTime);
         log.info("Finding bundles to update took {}s", fileQt);
-        log.info("documentsToUpdate: {}, bundlesToUpdate:{}", count.doubleValue(), hits.keySet().size());
+        log.info("documentsToUpdate: {}, bundlesToUpdate:{}", documents.size(), hits.keySet().size());
         return hits;
     }
 
@@ -114,8 +110,8 @@ public class BundleManifestService {
             return Optional.ofNullable(bundleManifest.getFileProjectMap());
         } else {
             throw new RuntimeException(String.format("Bundle manifest %s contains no entity map for entity type %s",
-                                                     bundleManifest.getId(),
-                                                     entityType.toString()));
+                    bundleManifest.getId(),
+                    entityType.toString()));
         }
     }
 

--- a/src/main/java/org/humancellatlas/ingest/core/service/MetadataCrudService.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/MetadataCrudService.java
@@ -11,6 +11,7 @@ import org.humancellatlas.ingest.state.ValidationState;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -67,5 +68,9 @@ public class MetadataCrudService {
 
     public <T extends MetadataDocument> Stream<T> findBySubmission(SubmissionEnvelope submissionEnvelope, EntityType entityType) {
         return crudStrategyForMetadataType(entityType).findBySubmissionEnvelope(submissionEnvelope);
+    }
+
+    public <T extends MetadataDocument> Collection<T> findAllBySubmission(SubmissionEnvelope submissionEnvelope, EntityType entityType) {
+        return crudStrategyForMetadataType(entityType).findAllBySubmissionEnvelope(submissionEnvelope);
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/MetadataCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/MetadataCrudStrategy.java
@@ -3,6 +3,7 @@ package org.humancellatlas.ingest.core.service.strategy;
 import org.humancellatlas.ingest.core.MetadataDocument;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 
+import java.util.Collection;
 import java.util.stream.Stream;
 
 public interface MetadataCrudStrategy <T extends MetadataDocument> {
@@ -10,4 +11,5 @@ public interface MetadataCrudStrategy <T extends MetadataDocument> {
     T findMetadataDocument(String id);
     T findOriginalByUuid(String uuid);
     Stream<T> findBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope);
+    Collection<T> findAllBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope);
 }

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/BiomaterialCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/BiomaterialCrudStrategy.java
@@ -9,6 +9,7 @@ import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
 
+import java.util.Collection;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -42,5 +43,10 @@ public class BiomaterialCrudStrategy implements MetadataCrudStrategy<Biomaterial
     @Override
     public Stream<Biomaterial> findBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope) {
         return biomaterialRepository.findBySubmissionEnvelope(submissionEnvelope);
+    }
+
+    @Override
+    public Collection<Biomaterial> findAllBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope) {
+        return biomaterialRepository.findAllBySubmissionEnvelope(submissionEnvelope);
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/FileCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/FileCrudStrategy.java
@@ -9,6 +9,7 @@ import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
 
+import java.util.Collection;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -41,5 +42,10 @@ public class FileCrudStrategy implements MetadataCrudStrategy<File> {
     @Override
     public Stream<File> findBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope) {
         return fileRepository.findBySubmissionEnvelope(submissionEnvelope);
+    }
+
+    @Override
+    public Collection<File> findAllBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope) {
+        return fileRepository.findAllBySubmissionEnvelope(submissionEnvelope);
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProcessCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProcessCrudStrategy.java
@@ -9,6 +9,7 @@ import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
 
+import java.util.Collection;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -41,5 +42,10 @@ public class ProcessCrudStrategy implements MetadataCrudStrategy<Process> {
     @Override
     public Stream<Process> findBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope) {
         return processRepository.findBySubmissionEnvelope(submissionEnvelope);
+    }
+
+    @Override
+    public Collection<Process> findAllBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope) {
+        return processRepository.findAllBySubmissionEnvelope(submissionEnvelope);
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProjectCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProjectCrudStrategy.java
@@ -9,6 +9,7 @@ import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
 
+import java.util.Collection;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -42,5 +43,10 @@ public class ProjectCrudStrategy implements MetadataCrudStrategy<Project> {
     @Override
     public Stream<Project> findBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope) {
         return projectRepository.findBySubmissionEnvelope(submissionEnvelope);
+    }
+
+    @Override
+    public Collection<Project> findAllBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope) {
+        return projectRepository.findAllBySubmissionEnvelope(submissionEnvelope);
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProtocolCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProtocolCrudStrategy.java
@@ -9,6 +9,7 @@ import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
 
+import java.util.Collection;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -41,5 +42,10 @@ public class ProtocolCrudStrategy implements MetadataCrudStrategy<Protocol> {
     @Override
     public Stream<Protocol> findBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope) {
         return protocolRepository.findBySubmissionEnvelope(submissionEnvelope);
+    }
+
+    @Override
+    public Collection<Protocol> findAllBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope) {
+        return protocolRepository.findAllBySubmissionEnvelope(submissionEnvelope);
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/export/DefaultExporter.java
+++ b/src/main/java/org/humancellatlas/ingest/export/DefaultExporter.java
@@ -19,104 +19,28 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Collection;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
 @Component
 public class DefaultExporter implements Exporter {
 
+    private final Logger log = LoggerFactory.getLogger(getClass());
     @Autowired
     private ProcessService processService;
-
     @Autowired
     private MetadataCrudService metadataCrudService;
-
     @Autowired
     private BundleManifestService bundleManifestService;
-
     @Autowired
     private BundleManifestRepository bundleManifestRepository;
-
     @Autowired
     private MessageRouter messageRouter;
-
     @Autowired
     private LinkGenerator linkGenerator;
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
-
-    @Override
-    public void exportBundles(SubmissionEnvelope envelope) {
-        Collection<String> assayingProcessIds = processService.findAssays(envelope);
-        Collection<String> analysisProcessIds = processService.findAnalyses(envelope);
-
-        log.info(String.format("Found %s assays and %s analysis processes for envelope with ID %s",
-                               assayingProcessIds.size(),
-                               analysisProcessIds.size(),
-                               envelope.getId()));
-
-        IndexCounter counter = new IndexCounter();
-        int totalCount = assayingProcessIds.size() + analysisProcessIds.size();
-
-        int partitionSize = 500;
-        partitionProcessIds(assayingProcessIds, partitionSize)
-                .stream()
-                .map(processIdBatch -> processService.getProcesses(processIdBatch))
-                .flatMap(Function.identity())
-                .map(process -> new ExportData(counter.next(), totalCount, process,  envelope))
-                .forEach(messageRouter::sendAssayForExport);
-
-        partitionProcessIds(analysisProcessIds, partitionSize)
-                .stream()
-                .map(processIdBatch -> processService.getProcesses(processIdBatch))
-                .flatMap(Function.identity())
-                .map(process -> new ExportData(counter.next(), totalCount, process,  envelope))
-                .forEach(messageRouter::sendAnalysisForExport);
-    }
-
-    @Override
-    public void updateBundles(SubmissionEnvelope submissionEnvelope) {
-    	// FIXME why do we need a whole collection of metadocument here?
-    	
-        Stream projects = metadataCrudService.findBySubmission(submissionEnvelope, EntityType.PROJECT);
-        Stream biomaterials = metadataCrudService.findBySubmission(submissionEnvelope, EntityType.BIOMATERIAL);
-        Stream protocols = metadataCrudService.findBySubmission(submissionEnvelope, EntityType.PROTOCOL);
-        Stream processes = metadataCrudService.findBySubmission(submissionEnvelope, EntityType.PROCESS);
-        Stream files = metadataCrudService.findBySubmission(submissionEnvelope, EntityType.FILE);
-        
-		Stream<MetadataDocument> documentsToUpdate = Stream.of(projects, biomaterials, protocols, processes, files).flatMap(i->i);
-        
-        Map<String, Set<MetadataDocument>> bundleManifestsToUpdate = bundleManifestService.bundleManifestsForDocuments(documentsToUpdate);
-        int totalCount = bundleManifestsToUpdate.size();
-
-        IndexCounter counter = new IndexCounter();
-        Uuid submissionUuid = submissionEnvelope.getUuid();
-        bundleManifestsToUpdate.keySet().stream().map(bundleManifestUuid -> {
-            MetadataDocumentMessageBuilder builder = MetadataDocumentMessageBuilder.using(linkGenerator)
-                    .withEnvelopeId(submissionEnvelope.getId())
-                    .withAssayIndex(counter.next())
-                    .withTotalAssays(totalCount);
-            if(submissionUuid != null && submissionUuid.getUuid() != null){
-                builder.withEnvelopeUuid(submissionUuid.getUuid().toString());
-            }
-            Optional<BundleManifest> maybeBundleManifest = bundleManifestRepository.findTopByBundleUuidOrderByBundleVersionDesc(bundleManifestUuid);
-            BundleUpdateMessage exportMessage = maybeBundleManifest.map(bundleManifest -> builder.buildBundleUpdateMessage(bundleManifest, bundleManifestsToUpdate.get(bundleManifestUuid)))
-                                                                   .orElseThrow(() -> {
-                                                                       throw new RuntimeException(String.format("Failed to find a bundle manifest for bundle UUID %s", bundleManifestUuid));
-                                                                   });
-
-            return exportMessage;
-        }).forEach(messageRouter::sendBundlesToUpdateForExport);
-    }
-
     /**
-     *
      * Divides a set of process IDs into lists of size partitionSize
      *
      * @param processIds
@@ -127,6 +51,66 @@ public class DefaultExporter implements Exporter {
         return ListUtils.partition(new ArrayList<>(processIds), partitionSize);
     }
 
+    @Override
+    public void exportBundles(SubmissionEnvelope envelope) {
+        Collection<String> assayingProcessIds = processService.findAssays(envelope);
+        Collection<String> analysisProcessIds = processService.findAnalyses(envelope);
+
+        log.info(String.format("Found %s assays and %s analysis processes for envelope with ID %s",
+                assayingProcessIds.size(),
+                analysisProcessIds.size(),
+                envelope.getId()));
+
+        IndexCounter counter = new IndexCounter();
+        int totalCount = assayingProcessIds.size() + analysisProcessIds.size();
+
+        int partitionSize = 500;
+        partitionProcessIds(assayingProcessIds, partitionSize)
+                .stream()
+                .map(processIdBatch -> processService.getProcesses(processIdBatch))
+                .flatMap(Function.identity())
+                .map(process -> new ExportData(counter.next(), totalCount, process, envelope))
+                .forEach(messageRouter::sendAssayForExport);
+
+        partitionProcessIds(analysisProcessIds, partitionSize)
+                .stream()
+                .map(processIdBatch -> processService.getProcesses(processIdBatch))
+                .flatMap(Function.identity())
+                .map(process -> new ExportData(counter.next(), totalCount, process, envelope))
+                .forEach(messageRouter::sendAnalysisForExport);
+    }
+
+    @Override
+    public void updateBundles(SubmissionEnvelope submissionEnvelope) {
+        Collection<MetadataDocument> documentsToUpdate = new ArrayList<>();
+        documentsToUpdate.addAll(metadataCrudService.findAllBySubmission(submissionEnvelope, EntityType.PROJECT));
+        documentsToUpdate.addAll(metadataCrudService.findAllBySubmission(submissionEnvelope, EntityType.BIOMATERIAL));
+        documentsToUpdate.addAll(metadataCrudService.findAllBySubmission(submissionEnvelope, EntityType.PROTOCOL));
+        documentsToUpdate.addAll(metadataCrudService.findAllBySubmission(submissionEnvelope, EntityType.PROCESS));
+        documentsToUpdate.addAll(metadataCrudService.findAllBySubmission(submissionEnvelope, EntityType.FILE));
+
+        Map<String, Set<MetadataDocument>> bundleManifestsToUpdate = bundleManifestService.bundleManifestsForDocuments(documentsToUpdate);
+        int totalCount = bundleManifestsToUpdate.size();
+
+        IndexCounter counter = new IndexCounter();
+        Uuid submissionUuid = submissionEnvelope.getUuid();
+        bundleManifestsToUpdate.keySet().stream().map(bundleManifestUuid -> {
+            MetadataDocumentMessageBuilder builder = MetadataDocumentMessageBuilder.using(linkGenerator)
+                    .withEnvelopeId(submissionEnvelope.getId())
+                    .withAssayIndex(counter.next())
+                    .withTotalAssays(totalCount);
+            if (submissionUuid != null && submissionUuid.getUuid() != null) {
+                builder.withEnvelopeUuid(submissionUuid.getUuid().toString());
+            }
+            Optional<BundleManifest> maybeBundleManifest = bundleManifestRepository.findTopByBundleUuidOrderByBundleVersionDesc(bundleManifestUuid);
+            BundleUpdateMessage exportMessage = maybeBundleManifest.map(bundleManifest -> builder.buildBundleUpdateMessage(bundleManifest, bundleManifestsToUpdate.get(bundleManifestUuid)))
+                    .orElseThrow(() -> {
+                        throw new RuntimeException(String.format("Failed to find a bundle manifest for bundle UUID %s", bundleManifestUuid));
+                    });
+
+            return exportMessage;
+        }).forEach(messageRouter::sendBundlesToUpdateForExport);
+    }
 
     private static class IndexCounter {
 

--- a/src/main/java/org/humancellatlas/ingest/file/FileRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/file/FileRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RestResource;
 import org.springframework.web.bind.annotation.CrossOrigin;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -54,4 +55,6 @@ public interface FileRepository extends MongoRepository<File, String> {
     public Page<File> findBySubmissionEnvelopeAndValidationState(@Param("envelopeUri") SubmissionEnvelope submissionEnvelope,
                                                                             @Param("state") ValidationState state,
                                                                             Pageable pageable);
+    @RestResource(exported = false)
+    Collection<File> findAllBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope);
 }

--- a/src/main/java/org/humancellatlas/ingest/migrations/MongoChangeLog.java
+++ b/src/main/java/org/humancellatlas/ingest/migrations/MongoChangeLog.java
@@ -10,8 +10,23 @@ import java.util.List;
 
 @ChangeLog
 public class MongoChangeLog {
-    @ChangeSet(order = "2019-11-02", id = "featureCompatibilityVersion 4.2", author = "alexie.staffer@ebi.ac.uk")
+    @ChangeSet(order = "2019-10-30", id="featureCompatibilityVersion 3.4", author = "alexie.staffer@ebi.ac.uk")
+    public void featureCompatibilityThreeFour(MongoDatabase db) {
+        db.runCommand( new Document("setFeatureCompatibilityVersion", "3.4") );
+    }
 
+    @ChangeSet(order = "2019-10-31", id="featureCompatibilityVersion 3.6", author = "alexie.staffer@ebi.ac.uk")
+    public void featureCompatibilityThreeSix(MongoDatabase db) {
+        db.runCommand( new Document("setFeatureCompatibilityVersion", "3.6") );
+    }
+
+    @ChangeSet(order = "2019-11-01", id="featureCompatibilityVersion 4.0", author = "alexie.staffer@ebi.ac.uk")
+    public void featureCompatibilityFourZero(MongoDatabase db) {
+        db.runCommand( new Document("setFeatureCompatibilityVersion", "4.0") );
+        db.runCommand( new Document("setFreeMonitoring", 1).append("action", "disable") );
+    }
+
+    @ChangeSet(order = "2019-11-02", id = "featureCompatibilityVersion 4.2", author = "alexie.staffer@ebi.ac.uk")
     public void featureCompatibilityFourTwo(MongoDatabase db) {
         db.runCommand(new Document("setFeatureCompatibilityVersion", "4.2"));
     }

--- a/src/main/java/org/humancellatlas/ingest/migrations/MongoChangeLog.java
+++ b/src/main/java/org/humancellatlas/ingest/migrations/MongoChangeLog.java
@@ -77,6 +77,6 @@ public class MongoChangeLog {
         List<Document> update = new ArrayList<>();
         update.add(new Document("$set", Document.parse("{ submissionEnvelope: { $arrayElemAt: [ \"$submissionEnvelopes\", 0 ] } }")));
 
-        db.getCollection("file").updateMany(filter, update);
+        db.getCollection("project").updateMany(filter, update);
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/migrations/MongoChangeLog.java
+++ b/src/main/java/org/humancellatlas/ingest/migrations/MongoChangeLog.java
@@ -10,28 +10,15 @@ import java.util.List;
 
 @ChangeLog
 public class MongoChangeLog {
-    @ChangeSet(order = "2019-10-30", id="featureCompatibilityVersion 3.4", author = "alexie.staffer@ebi.ac.uk")
-    public void featureCompatibilityThreeFour(MongoDatabase db) {
-        db.runCommand( new Document("setFeatureCompatibilityVersion", "3.4") );
-    }
+:q
 
-    @ChangeSet(order = "2019-10-31", id="featureCompatibilityVersion 3.6", author = "alexie.staffer@ebi.ac.uk", runAlways = true)
-    public void featureCompatibilityThreeSix(MongoDatabase db) {
-        db.runCommand( new Document("setFeatureCompatibilityVersion", "3.6") );
-    }
+    @ChangeSet(order = "2019-11-02", id = "featureCompatibilityVersion 4.2", author = "alexie.staffer@ebi.ac.uk")
 
-    @ChangeSet(order = "2019-11-01", id="featureCompatibilityVersion 4.0", author = "alexie.staffer@ebi.ac.uk")
-    public void featureCompatibilityFourZero(MongoDatabase db) {
-        db.runCommand( new Document("setFeatureCompatibilityVersion", "4.0") );
-        db.runCommand( new Document("setFreeMonitoring", 1).append("action", "disable") );
-    }
-
-    @ChangeSet(order = "2019-11-02", id="featureCompatibilityVersion 4.2", author = "alexie.staffer@ebi.ac.uk")
     public void featureCompatibilityFourTwo(MongoDatabase db) {
-        db.runCommand( new Document("setFeatureCompatibilityVersion", "4.2") );
+        db.runCommand(new Document("setFeatureCompatibilityVersion", "4.2"));
     }
 
-    @ChangeSet(order = "2019-11-03", id="singletonSubmissionEnvelope Biomaterial", author = "alexie.staffer@ebi.ac.uk")
+    @ChangeSet(order = "2019-11-03", id = "singletonSubmissionEnvelope Biomaterial", author = "alexie.staffer@ebi.ac.uk")
     public void singletonSubmissionEnvelopeBiomaterial(MongoDatabase db) {
         Document filter = new Document();
         List<Document> update = new ArrayList<>();
@@ -41,7 +28,7 @@ public class MongoChangeLog {
         db.getCollection("biomaterial").updateMany(filter, update);
     }
 
-    @ChangeSet(order = "2019-11-04", id="singletonSubmissionEnvelope Process", author = "alexie.staffer@ebi.ac.uk")
+    @ChangeSet(order = "2019-11-04", id = "singletonSubmissionEnvelope Process", author = "alexie.staffer@ebi.ac.uk")
     public void singletonSubmissionEnvelopeProcess(MongoDatabase db) {
         Document filter = new Document();
         List<Document> update = new ArrayList<>();
@@ -51,7 +38,7 @@ public class MongoChangeLog {
         db.getCollection("process").updateMany(filter, update);
     }
 
-    @ChangeSet(order = "2019-11-05", id="singletonSubmissionEnvelope Protocol", author = "alexie.staffer@ebi.ac.uk")
+    @ChangeSet(order = "2019-11-05", id = "singletonSubmissionEnvelope Protocol", author = "alexie.staffer@ebi.ac.uk")
     public void singletonSubmissionEnvelopeProtocol(MongoDatabase db) {
         Document filter = new Document();
         List<Document> update = new ArrayList<>();
@@ -61,12 +48,21 @@ public class MongoChangeLog {
         db.getCollection("protocol").updateMany(filter, update);
     }
 
-    @ChangeSet(order = "2019-11-06", id="singletonSubmissionEnvelope File", author = "alexie.staffer@ebi.ac.uk")
+    @ChangeSet(order = "2019-11-06", id = "singletonSubmissionEnvelope File", author = "alexie.staffer@ebi.ac.uk")
     public void singletonSubmissionEnvelopeFile(MongoDatabase db) {
         Document filter = new Document();
         List<Document> update = new ArrayList<>();
         update.add(new Document("$set", Document.parse("{ submissionEnvelope: { $arrayElemAt: [ \"$submissionEnvelopes\", 0 ] } }")));
         update.add(new Document("$unset", "submissionEnvelopes"));
+
+        db.getCollection("file").updateMany(filter, update);
+    }
+
+    @ChangeSet(order = "2019-11-07", id = "singletonSubmissionEnvelope Project", author = "alexie.staffer@ebi.ac.uk")
+    public void singletonSubmissionEnvelopeProject(MongoDatabase db) {
+        Document filter = new Document();
+        List<Document> update = new ArrayList<>();
+        update.add(new Document("$set", Document.parse("{ submissionEnvelope: { $arrayElemAt: [ \"$submissionEnvelopes\", 0 ] } }")));
 
         db.getCollection("file").updateMany(filter, update);
     }

--- a/src/main/java/org/humancellatlas/ingest/migrations/MongoChangeLog.java
+++ b/src/main/java/org/humancellatlas/ingest/migrations/MongoChangeLog.java
@@ -10,8 +10,6 @@ import java.util.List;
 
 @ChangeLog
 public class MongoChangeLog {
-:q
-
     @ChangeSet(order = "2019-11-02", id = "featureCompatibilityVersion 4.2", author = "alexie.staffer@ebi.ac.uk")
 
     public void featureCompatibilityFourTwo(MongoDatabase db) {

--- a/src/main/java/org/humancellatlas/ingest/migrations/MongoChangeLog.java
+++ b/src/main/java/org/humancellatlas/ingest/migrations/MongoChangeLog.java
@@ -15,7 +15,7 @@ public class MongoChangeLog {
         db.runCommand( new Document("setFeatureCompatibilityVersion", "3.4") );
     }
 
-    @ChangeSet(order = "2019-10-31", id="featureCompatibilityVersion 3.6", author = "alexie.staffer@ebi.ac.uk")
+    @ChangeSet(order = "2019-10-31", id="featureCompatibilityVersion 3.6", author = "alexie.staffer@ebi.ac.uk", runAlways = true)
     public void featureCompatibilityThreeSix(MongoDatabase db) {
         db.runCommand( new Document("setFeatureCompatibilityVersion", "3.6") );
     }

--- a/src/main/java/org/humancellatlas/ingest/migrations/MongoChangeLog.java
+++ b/src/main/java/org/humancellatlas/ingest/migrations/MongoChangeLog.java
@@ -10,20 +10,20 @@ import java.util.List;
 
 @ChangeLog
 public class MongoChangeLog {
-    @ChangeSet(order = "2019-10-30", id="featureCompatibilityVersion 3.4", author = "alexie.staffer@ebi.ac.uk")
+    @ChangeSet(order = "2019-10-30", id = "featureCompatibilityVersion 3.4", author = "alexie.staffer@ebi.ac.uk")
     public void featureCompatibilityThreeFour(MongoDatabase db) {
-        db.runCommand( new Document("setFeatureCompatibilityVersion", "3.4") );
+        db.runCommand(new Document("setFeatureCompatibilityVersion", "3.4"));
     }
 
-    @ChangeSet(order = "2019-10-31", id="featureCompatibilityVersion 3.6", author = "alexie.staffer@ebi.ac.uk")
+    @ChangeSet(order = "2019-10-31", id = "featureCompatibilityVersion 3.6", author = "alexie.staffer@ebi.ac.uk")
     public void featureCompatibilityThreeSix(MongoDatabase db) {
-        db.runCommand( new Document("setFeatureCompatibilityVersion", "3.6") );
+        db.runCommand(new Document("setFeatureCompatibilityVersion", "3.6"));
     }
 
-    @ChangeSet(order = "2019-11-01", id="featureCompatibilityVersion 4.0", author = "alexie.staffer@ebi.ac.uk")
+    @ChangeSet(order = "2019-11-01", id = "featureCompatibilityVersion 4.0", author = "alexie.staffer@ebi.ac.uk")
     public void featureCompatibilityFourZero(MongoDatabase db) {
-        db.runCommand( new Document("setFeatureCompatibilityVersion", "4.0") );
-        db.runCommand( new Document("setFreeMonitoring", 1).append("action", "disable") );
+        db.runCommand(new Document("setFeatureCompatibilityVersion", "4.0"));
+        db.runCommand(new Document("setFreeMonitoring", 1).append("action", "disable"));
     }
 
     @ChangeSet(order = "2019-11-02", id = "featureCompatibilityVersion 4.2", author = "alexie.staffer@ebi.ac.uk")

--- a/src/main/java/org/humancellatlas/ingest/process/ProcessRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/process/ProcessRepository.java
@@ -42,4 +42,6 @@ public interface ProcessRepository extends MongoRepository<Process, String> {
     @RestResource(exported = false)
     public Stream<Process> findAllByIdIn(Collection<String> ids);
 
+    @RestResource(exported = false)
+    Collection<Process> findAllBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope);
 }

--- a/src/main/java/org/humancellatlas/ingest/project/ProjectRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/project/ProjectRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RestResource;
 import org.springframework.web.bind.annotation.CrossOrigin;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -48,4 +49,7 @@ public interface ProjectRepository extends MongoRepository<Project, String> , Pr
     
     
     Page<Project> findByContent(List<MetadataCriteria> criteria, Pageable pageable);
+
+    @RestResource(exported = false)
+    Collection<Project> findAllBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope);
 }

--- a/src/main/java/org/humancellatlas/ingest/protocol/ProtocolRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/protocol/ProtocolRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RestResource;
 import org.springframework.web.bind.annotation.CrossOrigin;
 
+import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -39,4 +40,7 @@ public interface ProtocolRepository extends MongoRepository<Protocol, String> {
 
     @RestResource(rel = "findByUuid", path = "findByUuid")
     Optional<Protocol> findByUuidUuidAndIsUpdateFalse(@Param("uuid") UUID uuid);
+
+    @RestResource(exported = false)
+    Collection<Protocol> findAllBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope);
 }


### PR DESCRIPTION
looks like stream is not the best thing to use here,
> A stream should be operated on (invoking an intermediate or terminal stream operation) only once.
https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html

If we recreate the stream by doing the query again thru the Supplier, it would be too costly. I’m gonna revert to using the list. This code which search the bundle manifest to update is very inefficient and there’s a plan to reimplement this. I believe the use of list here is our best option for now. 

See thread: https://humancellatlas.slack.com/archives/GE613S72S/p1573144395012400

Requires dev to be using mongo 4.2 